### PR TITLE
Remove some SciPy dependencies

### DIFF
--- a/goftests/test.py
+++ b/goftests/test.py
@@ -49,12 +49,22 @@ from goftests import auto_density_goodness_of_fit
 from goftests import mixed_density_goodness_of_fit
 from goftests import split_discrete_continuous
 from goftests import volume_of_sphere
+from goftests import chi2sf
 
 NUM_BASE_SAMPLES = 250
 
 NUM_SAMPLES_SCALE = 1000
 
 TEST_FAILURE_RATE = 5e-4
+
+
+def test_chi2cdf(xmin=0.0, xmax=100.0, nx=500, smin=1, smax=41, sstep=1.5):
+    xlist = numpy.linspace(xmin, xmax, nx)
+    slist = numpy.arange(smin, smax, sstep)
+    for s in slist:
+        for x in xlist:
+            delta = scipy.stats.chi2.sf(x, s) - chi2sf(x, s)
+            assert_almost_equal(delta, 0.0)
 
 
 def test_multinomial_goodness_of_fit():

--- a/goftests/utils.py
+++ b/goftests/utils.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2014, Salesforce.com, Inc.  All rights reserved.
+# Copyright (c) 2015-2016, Gamelan Labs, Inc.
+# Copyright (c) 2016, Google, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# - Neither the name of Salesforce.com nor the names of its contributors
+#   may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This module computes the chi^2 survival function and the required
+functions.
+"""
+
+from __future__ import division
+import math
+import sys
+
+
+def log(x):
+    if x > sys.float_info.min:
+        value = math.log(x)
+    else:
+        value = -float('inf')
+    return value
+
+
+def incomplete_gamma(x, s):
+    r"""
+    This function computes the incomplete lower gamma function
+    using the series expansion:
+
+    .. math::
+
+       \gamma(x, s) = x^s \Gamma(s)e^{-x}\sum^\infty_{k=0}
+                    \frac{x^k}{\Gamma(s + k + 1)}
+
+    This series will converge strongly because the Gamma
+    function grows factorially.
+
+    Because the Gamma function does grow so quickly, we can
+    run into numerical stability issues. To solve this we carry
+    out as much math as possible in the log domain to reduce
+    numerical error. This function matches the results from
+    scipy to numerical precision.
+    """
+    value = 0.0
+    if x < 0.0:
+        return 1.0
+    if x > 1e3:
+        return math.gamma(s)
+    log_gamma_s = math.lgamma(s)
+    log_x = log(x)
+    for k in range(0, 100):
+        log_num = (k + s)*log_x + (-x) + log_gamma_s
+        log_denom = math.lgamma(k + s + 1)
+        value += math.exp(log_num - log_denom)
+    return value
+
+
+def chi2sf(x, s):
+    r"""
+    This function returns the survival function of the chi^2
+    distribution. The survival function is given as:
+
+    .. math::
+       1 - CDF
+
+    where rhe chi^2 CDF is given as
+
+    .. math::
+       F(x; s) = \frac{ \gamma( x/2, s/2 ) }{ \Gamma(s/2) },
+
+    with :math:`\gamma` is the incomplete gamma function defined above.
+    Therefore, the survival probability is givne by:
+
+    .. math::
+       1 - \frac{ \gamma( x/2, s/2 ) }{ \Gamma(s/2) }.
+
+    This function matches the results from
+    scipy to numerical precision.
+    """
+    top = incomplete_gamma(x/2.0, s/2.0)
+    bottom = math.gamma(s/2.0)
+    value = top/bottom
+    return 1.0 - value

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 nose
+scipy
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 scipy
-scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ config = {
     'maintainer': 'Fritz Obermeyer',
     'maintainer_email': 'fritz.obermeyer@gmail.com',
     'license': 'Revised BSD',
-    'install_requires': ['numpy', 'scipy', 'scikit-learn'],
+    'install_requires': ['numpy', 'scipy'],
     'packages': ['goftests'],
     'tests_require': ['nose'],
     'test_suite': 'nose.collector',


### PR DESCRIPTION
I have removed the scipy dependencies by using the gamma function that the python math module provides, and implementing my own $\chi^2$ survival function. This was done so that I could use goftests with pypy.

I have also included a test for my new $\chi^2$ survival function, and verified that it agrees with the scipy provided version to machine precision.  
