### PR TITLE
Uses KDTree from python-kdtree package, not SciPy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@
 
 test:
 	find . -type f -name \*.py -exec flake8 {} \;
-	nosetests -v goftests
+	python -m unittest discover
 	@echo '------------'
 	@echo 'PASSED TESTS'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
-nose
 scipy
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+kdtree
 numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 kdtree
 numpy
-scipy

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ config = {
     'maintainer': 'Fritz Obermeyer',
     'maintainer_email': 'fritz.obermeyer@gmail.com',
     'license': 'Revised BSD',
-    'install_requires': ['numpy', 'scipy'],
+    'install_requires': ['kdtree', 'numpy', 'scipy'],
     'packages': ['goftests'],
     'test_suite': 'goftests.test',
     'include_package_data': True,

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,10 @@ config = {
     'maintainer': 'Fritz Obermeyer',
     'maintainer_email': 'fritz.obermeyer@gmail.com',
     'license': 'Revised BSD',
-    'install_requires': ['kdtree', 'numpy', 'scipy'],
+    'install_requires': ['kdtree', 'numpy'],
     'packages': ['goftests'],
     'test_suite': 'goftests.test',
+    'tests_require': ['scipy'],
     'include_package_data': True,
 }
 


### PR DESCRIPTION
This fixes issue #12.

*What change does this make?* This replaces the `scipy.spatial.cKDtree` with the `kdtree` from the [python-kdtree][1] package.

[1]: https://github.com/stefankoegl/kdtree

*How does this affect the user?* The user should see no difference (other than the fact that an additional dependency is downloaded and installed when `goftests` is installed). This is purely an implementation change, and all the tests pass.

*Why is this better than the alternative?* While I'm assuming SciPy C implementation is faster, this pull request, along with pull request #10, will entirely remove the dependency on SciPy. This will help `goftests` run on PyPy.

*What changes does this not make?* There is a possible optimization to be done here: the kdtree implementation returns squared distance. Instead of computing the square root of that and passing that distance directly to `volume_of_sphere`, we could change `volume_of_sphere` to take a squared radius as input instead, and use the `0.5 * dim` exponent which is already computed in the formula.