### PR TITLE
Use MANIFEST.in and setup.cfg to install LICENSE.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [metadata]
 description-file = README.md
+license-file = LICENSE.txt
+
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@
 
 from setuptools import setup
 
-VERSION = '0.2.4'
+VERSION = '0.2.5'
 description = 'Goodness of fit tests for general datatypes'
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ config = {
     'packages': ['goftests'],
     'tests_require': ['nose'],
     'test_suite': 'nose.collector',
-    'data_files': [('', ['LICENSE.txt'])],
+    'include_package_data': True,
 }
 
 setup(**config)


### PR DESCRIPTION
Okay, after a bunch of trial-and-error, this method seems to package the LICENSE.txt file into both the sdist .tar.gz and the bdist_wheel .whl.

Also, because it includes MANIFEST.in, hopefully this solves #16 (and comments in #13), in case @fritzo is using a different packaging method than sdist.