### PR TITLE
Replace numpy.testing.rand with numpy.random.rand.

### DIFF
--- a/goftests/test.py
+++ b/goftests/test.py
@@ -40,7 +40,7 @@ from unittest import TestCase
 import numpy
 import scipy.stats
 from numpy import pi
-from numpy.testing import rand
+from numpy.random import rand
 
 from goftests import get_dim
 from goftests import multinomial_goodness_of_fit


### PR DESCRIPTION
Fixes issue #19.

`numpy.testing.rand()` was deprecated in NumPy 1.11 in favor of `numpy.random.rand()`.