### PR TITLE
 Remove tests for scipy.stats.frechet_l/r.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 Copyright (c) 2014, Salesforce.com, Inc.  All rights reserved.
 Copyright (c) 2015, Gamelan Labs, Inc.
 Copyright (c) 2016, Google, Inc.
+Copyright (c) 2019, Gamalon, Inc. <br/>
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/README.md
+++ b/README.md
@@ -130,5 +130,6 @@ or reduce to standard tests in another package like
 Copyright (c) 2014 Salesforce.com, Inc. All rights reserved. <br/>
 Copyright (c) 2015 Gamelan Labs, Inc. <br/>
 Copyright (c) 2016 Google, Inc. <br/>
+Copyright (c) 2019 Gamalon, Inc. <br/>
 Licensed under the Revised BSD License.
 See [LICENSE.txt](LICENSE.txt) for details.

--- a/goftests/__init__.py
+++ b/goftests/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2014, Salesforce.com, Inc.  All rights reserved.
 # Copyright (c) 2015, Gamelan Labs, Inc.
 # Copyright (c) 2016, Google, Inc.
+# Copyright (c) 2019, Gamalon, Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/goftests/test.py
+++ b/goftests/test.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2015, Gamelan Labs, Inc.
 # Copyright (c) 2016, Google, Inc.
 # Copyright (c) 2016, Gamelan Labs, Inc.
+# Copyright (c) 2019, Gamalon, Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/goftests/test.py
+++ b/goftests/test.py
@@ -495,16 +495,6 @@ class TestFoldedNormal(ContinuousTestBase, TestCase):
     dist = scipy.stats.foldnorm
 
 
-class TestFrechetRight(ContinuousTestBase, TestCase):
-
-    dist = scipy.stats.frechet_r
-
-
-class TestFrechetLeft(ContinuousTestBase, TestCase):
-
-    dist = scipy.stats.frechet_l
-
-
 class TestGeneralizedLogistic(ContinuousTestBase, TestCase):
 
     dist = scipy.stats.genlogistic
@@ -827,11 +817,13 @@ class TestWald(ContinuousTestBase, TestCase):
 
 class TestWeibullMin(ContinuousTestBase, TestCase):
 
+    # This also covers what was previously available as `frechet_r`.
     dist = scipy.stats.weibull_min
 
 
 class TestWeibullMax(ContinuousTestBase, TestCase):
 
+    # This also covers what was previously available as `frechet_l`.
     dist = scipy.stats.weibull_max
 
 

--- a/update_license.py
+++ b/update_license.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2014, Salesforce.com, Inc.  All rights reserved.
 # Copyright (c) 2015, Gamelan Labs, Inc.
 # Copyright (c) 2016, Google, Inc.
+# Copyright (c) 2019, Gamalon, Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions


### PR DESCRIPTION
These functions are deprecated in favor of `weibull_min()` and
`weibull_max()` as of SciPy version 1.0.0.

Also updated the copyright information for 2019.